### PR TITLE
do not pass [] as arguments to first step

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -121,7 +121,7 @@ function Step() {
   };
 
   // Start the engine an pass nothing to the first step.
-  next([]);
+  next();
 }
 
 // Tack on leading and tailing steps for input and output and return


### PR DESCRIPTION
Usually one uses function(err) { if (err) throw err; /\* ... */ } for error propagation, but (!![]]) evaluates to true. I was researching for this for too long.
