### PR TITLE
Support all arguments on callback instead of just 1

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -77,7 +77,10 @@ function Step() {
         results[0] = arguments[0];
       }
       // Send the other results as arguments
-      results[i + 1] = [].splice.call(arguments,1);
+      if (arguments.length > 2)
+        results[i + 1] = [].splice.call(arguments,1);
+      else
+        results[i + 1] = arguments[1];
       if (lock) {
         process.nextTick(check);
         return
@@ -109,7 +112,10 @@ function Step() {
           error = arguments[0];
         }
         // Send the other results as arguments
-        result[i] = [].splice.call(arguments,1);
+        if (arguments.length > 2)
+          result[i] = [].splice.call(arguments,1);
+        else
+          result[i] = arguments[1];
         if (lock) {
           process.nextTick(check);
           return


### PR DESCRIPTION
In the code below, the request module sends the body as the second argument to the callback and i was not getting it passed to me. This makes a change to send all the arguments. So it becomes an array of arrays. 

```
var request = require('request');
var Step = require('step');

var sites = ["www.google.com", "www.yahoo.com", "www.linkedin.com", "www.apple.com", "facebook.com", "palm.com"];


Step(
  function() {
    var group = this.group();
    for (var i=0; i < sites.length; i++) {
      request({uri: "http://" + sites[i]}, group());
    }
   },

  function(err, responses) {
    for (var i = 1; i < responses.length; i++) {
        console.log(responses[i][1]);
        console.log("=======================");
      };
  }
)
```
