### PR TITLE
A bug in Step

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -26,7 +26,7 @@ SOFTWARE.
 // modified to fit my taste and the node.JS error handling system.
 function Step() {
   var steps = Array.prototype.slice.call(arguments),
-      pending, counter, results, lock;
+      pending, counter, results, lock, fired;
 
   // Define the main callback that's given as `this` to the steps.
   function next() {
@@ -64,16 +64,25 @@ function Step() {
 
   // Add a special callback generator `this.parallel()` that groups stuff.
   next.parallel = function () {
+    if (!counter) {
+      fired = false;
+    }
     var index = 1 + counter++;
     pending++;
 
-    function check() {
+    function check(caller) {
       if (pending === 0) {
         // When they're all done, call the callback
+        if (caller && fired) {
+          return;
+        }
         next.apply(null, results);
       }
     }
-    process.nextTick(check); // Ensures that check is called at least once
+    process.nextTick(function() {
+      check('nextTick');
+      fired = true;
+    }); // Ensures that check is called at least once
 
     return function () {
       pending--;
@@ -83,7 +92,10 @@ function Step() {
       }
       // Send the other results as arguments
       results[index] = arguments[1];
-      if (!lock) { check(); }
+      if (!lock) { 
+        check();
+        fired = true;
+      }
     };
   };
 

--- a/test/sequenceTest.js
+++ b/test/sequenceTest.js
@@ -1,0 +1,42 @@
+require('./helper');
+var fs = require('fs');
+
+function C(param, callback) {
+    console.log('C');
+    Step(
+        function D() {
+            console.log('D');
+            fs.readFile(param, this);
+        },
+
+        function E(err, some_data) {
+            console.log('E');
+            this(undefined, some_data);
+        },
+
+        callback
+    );
+}
+
+function quick_io(callback) {
+    callback('1');
+}
+
+Step(
+    function A() {
+        console.log('A');
+        quick_io(this.parallel());
+        quick_io(this.parallel());
+    },
+
+    function B(err, data1, data2) {
+        console.log('B');
+        // read some big file or directory
+        C('/tmp', this);
+    },
+
+    function F(err) {
+        console.log('F');
+    }
+
+);


### PR DESCRIPTION
I think I've found a bug in step, which may cause code executing order to be changed. 

This happens when function `check` in next.parallel executed before the Step sequence finished.

Here is an small example illustrating this:

```
function C(param, callback) {
    Step(
        function D(){
            do_some_IO(param, this);
        },

        function E(err, some_data){
            this(undefined, some_data);
        },

        callback
    );
}


Step(
    function A(err) {
        IO1(data, this.parallel();
        IO2(data, this.parallel());
    },

    function B(err, data1, data2) {
        C(data, this);
    },

    function F(err, data) {
        // finish
    }
);
```

 we write this code expecting it running in this order, A->B->C->D->E->F, 
 but in fact, the order may be changed to A->B->C->D->F->E

when A is executing, this.parallel() will set 2 process.nextTick in step,
then, when D is performing IO, process.nextTick begins as the the next event loop, and F is shifted from the queue and executed as the next fn in step(in function `next`), thus F will be executed before E, causing the whole program in error.

So I suggest that we could add a variable telling whether `check` has been executed by callback, and avoid executing `check` if `check` has been invoked by callback. By the way, I think function `next.group` is suffering from the same bug, but I did not write code to prove it.

I encountered this problem when modifying code of [wheat](https://github.com/creationix/wheat). Thanks a lot for writing such great code.

regards,
zTrix
