### PR TITLE
Added explicit function parameters to help readability

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -29,14 +29,14 @@ function Step() {
       pending, counter, results, lock;
 
   // Define the main callback that's given as `this` to the steps.
-  function next() {
+  function next(err) {
     counter = pending = 0;
 
     // Check if there are no steps left
     if (steps.length === 0) {
       // Throw uncaught errors
-      if (arguments[0]) {
-        throw arguments[0];
+      if (err) {
+        throw err;
       }
       return;
     }
@@ -70,14 +70,14 @@ function Step() {
     var index = 1 + counter++;
     pending++;
 
-    return function () {
+    return function (err, result) {
       pending--;
       // Compress the error from any result to the first argument
-      if (arguments[0]) {
-        results[0] = arguments[0];
+      if (err) {
+        results[0] = err;
       }
       // Send the other results as arguments
-      results[index] = arguments[1];
+      results[index] = result;
       if (!lock && pending === 0) {
         // When all parallel branches done, call the callback
         next.apply(null, results);
@@ -90,13 +90,13 @@ function Step() {
     var localCallback = next.parallel();
     var counter = 0;
     var pending = 0;
-    var result = [];
+    var results = [];
     var error = undefined;
 
     function check() {
       if (pending === 0) {
         // When group is done, call the callback
-        localCallback(error, result);
+        localCallback(error, results);
       }
     }
     process.nextTick(check); // Ensures that check is called at least once
@@ -105,14 +105,14 @@ function Step() {
     return function () {
       var index = counter++;
       pending++;
-      return function () {
+      return function (err, result) {
         pending--;
         // Compress the error from any result to the first argument
-        if (arguments[0]) {
-          error = arguments[0];
+        if (err) {
+          error = err;
         }
         // Send the other results as arguments
-        result[index] = arguments[1];
+        results[index] = result;
         if (!lock) { check(); }
       };
     };


### PR DESCRIPTION
In a number of places, Step uses the `arguments` variable to retrieve error and result parameters.  I found this made the code difficult to follow while debugging.  This patch tries to take advantage of named parameters where possible to help improve readability.
