### PR TITLE
Only call process.nextTick if it's defined

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -99,8 +99,11 @@ function Step() {
         localCallback(error, result);
       }
     }
-    process.nextTick(check); // Ensures that check is called at least once
-
+    
+    if (process && typeof process.nextTick == 'function') {
+      process.nextTick(check); // Ensures that check is called at least once  
+    }
+    
     // Generates a callback for the group
     return function () {
       var index = counter++;


### PR DESCRIPTION
Adding this check allows the library to be used outside of node.js.

This is very useful for me, because I'd like to try and use step.js on a front end application to help keep my code as clean as possible.
