### PR TITLE
module.export correction for Step

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -148,5 +148,5 @@ Step.fn = function StepFn() {
 
 // Hook into commonJS module systems
 if (typeof module !== 'undefined' && "exports" in module) {
-  module.exports = Step;
+  module.exports.Step = Step;
 }


### PR DESCRIPTION
I use step with var pasos = require('./step.js');
I correct module.export in step.js last lines.
module.exports.Step = Step;

Best regards from Lima-Perú
JJMiranda