### PR TITLE
Ability to exit a Step chain before finishing all registered steps

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -118,6 +118,10 @@ function Step() {
     };
   };
 
+  next.exitChain = function () {
+    steps = new Array();
+  }
+
   // Start the engine an pass nothing to the first step.
   next();
 }

--- a/test/exitChain.js
+++ b/test/exitChain.js
@@ -1,0 +1,25 @@
+require('./helper');
+
+var selfText = fs.readFileSync(__filename, 'utf8');
+
+// This example tests stopping a step chain before running all the registered steps
+
+expect('one');
+expect('two');
+Step(
+  function readSelf() {
+    fulfill("one");
+    fs.readFile(__filename, 'utf8', this);
+  },
+  function capitalize(err, text) {
+    fulfill("two");
+    if (err) throw err;
+    assert.equal(selfText, text, "Text Loaded");
+    return this.exitChain();
+  },
+  function showIt(err, newText) {
+    expect("three");
+    if (err) throw err;
+    assert.equal(selfText.toUpperCase(), newText, "Text Uppercased");
+  }
+);


### PR DESCRIPTION
I started to convert all the asynchronous calls of a project I'm currently working on to use Step.
Everything worked perfectly. However we had some problems in the following use case:

We need to perform three asynchronous calls to a database before we did some calculations.

Sometimes, during the second async call, an error would occur and we needed to stop executing and send a message back to the client.

The problem was that if we returned from the function that caught the error, it would go on to execute the next Step call. We wanted to stop the execution completely and send a response back to the client indicating the error.

The proposed patch adds a new function to the |next| object.
The exitChain function clears the array with the registered Step calls, thus stopping the execution whenever exitChain is called.

I also added a unit test to check the new feature.
