### PR TITLE
nextTick fallback with setImmediate and setTimeout

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -151,7 +151,7 @@ if (typeof process === 'undefined' || !(process.nextTick)) {
     Step.nextTick = function(fn){
       setImmediate(fn)
     };
-  }else{
+  } else {
     Step.nextTick = function (fn) {
       setTimeout(fn, 0);
     };


### PR DESCRIPTION
Uses setImmediate instead of setTimeout as a fallback for nextTick when setImmediate is available. Improves prabirshrestha's browser fallback in IE10+ and makes Step work with setImmediate polyfills. Related to #45 and #32.
