### PR TITLE
group: make 'result-as-the-first-parameter' from EventEmitters available

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -86,7 +86,7 @@ function Step() {
   };
 
   // Generates a callback generator for grouped results
-  next.group = function () {
+  next.group = function (resFirst) {
     var localCallback = next.parallel();
     var counter = 0;
     var pending = 0;
@@ -107,12 +107,14 @@ function Step() {
       pending++;
       return function () {
         pending--;
-        // Compress the error from any result to the first argument
-        if (arguments[0]) {
+        if (resFirst) {
+          result[index] = arguments[0];
+        } else if (arguments[0]) {
+          // Compress the error from any result to the first argument
           error = arguments[0];
+          // Send the other results as arguments
+          result[index] = arguments[1];
         }
-        // Send the other results as arguments
-        result[index] = arguments[1];
         if (!lock) { check(); }
       };
     };


### PR DESCRIPTION
From http://howtonode.org/control-flow-part-ii:

> For cases where there are more than two events
> and/or they can be called multiple times, then
> you need the more _powerful_ and _flexible_ EventEmitters.

Using `group()` for `http.get()` which is EventEmitter isn't
possible with Step's only "The Node.js Callback style"...
