### PR TITLE
Alter parallel() and group() functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 step follows [Semantic Versioning][semver].
 
+## 1.0.1 - 2017-05-16
+
+### Fixed
+
+* Fixed parallel() and group() returning undefined instead of null for error
+* Fixed parallel() and group() only returning one argument
+
 ## 1.0.0 - 2017-01-05
 
 ### Improved

--- a/lib/step.js
+++ b/lib/step.js
@@ -43,7 +43,7 @@ function Step() {
 
     // Get the next step to execute
     var fn = steps.shift();
-    results = [];
+    results = [null];
 
     // Run the step in a try..catch block so exceptions don't get out of hand.
     try {
@@ -60,43 +60,48 @@ function Step() {
       next.apply(null, results);
     } else if (result !== undefined) {
       // If a synchronous return is used, pass it to the callback
-      next(undefined, result);
+      next(null, result);
     }
     lock = false;
   }
 
   // Add a special callback generator `this.parallel()` that groups stuff.
-  next.parallel = function () {
+  next.parallel = function (isGrouped) {
     var index = 1 + counter++;
     pending++;
 
-    return function () {
+    return function (err, ...args) {
       pending--;
       // Compress the error from any result to the first argument
-      if (arguments[0]) {
-        results[0] = arguments[0];
+      if (err) {
+        results[0] = err;
       }
       // Send the other results as arguments
-      results[index] = arguments[1];
+      results[index] = args;
       if (!lock && pending === 0) {
         // When all parallel branches done, call the callback
-        next.apply(null, results);
+        if (isGrouped) {
+            next.apply(null, [results[0], ...results[1]]);
+        }
+        else {
+            next.apply(null, results);
+        }
       }
     };
   };
 
   // Generates a callback generator for grouped results
   next.group = function () {
-    var localCallback = next.parallel();
+    var localCallback = next.parallel(true);
     var counter = 0;
     var pending = 0;
-    var result = [];
-    var error = undefined;
+    var result = [[]];
+    var error = null;
 
     function check() {
       if (pending === 0) {
         // When group is done, call the callback
-        localCallback(error, result);
+        localCallback(error, ...result);
       }
     }
     process.nextTick(check); // Ensures that check is called at least once
@@ -105,14 +110,19 @@ function Step() {
     return function () {
       var index = counter++;
       pending++;
-      return function () {
+      return function (err, ...args) {
         pending--;
         // Compress the error from any result to the first argument
-        if (arguments[0]) {
-          error = arguments[0];
+        if (err) {
+          error = err;
         }
         // Send the other results as arguments
-        result[index] = arguments[1];
+        for (var i=0; i<args.length; i++) {
+            if (result[i] === undefined) {
+                result[i] = [];
+            }
+            result[i][index] = args[i];
+        }
         if (!lock) { check(); }
       };
     };

--- a/lib/step.js
+++ b/lib/step.js
@@ -24,139 +24,135 @@ SOFTWARE.
 
 // Inspired by http://github.com/willconant/flow-js, but reimplemented and
 // modified to fit my taste and the node.JS error handling system.
-function Step() {
-  var steps = Array.prototype.slice.call(arguments),
-      pending, counter, results, lock;
+// futher modified by Sandon Joubert <sandon.joubert1@gmail.com> with minor
+//  functionality changes, and bug fixes, now requires nodejs >= 6.0.0
+function Step(...steps) {
+	var pending, counter, results, lock;
 
-  // Define the main callback that's given as `this` to the steps.
-  function next() {
-    counter = pending = 0;
+	// Define the main callback that's given as `this` to the steps.
+	function next() {
+		counter = pending = 0;
 
-    // Check if there are no steps left
-    if (steps.length === 0) {
-      // Throw uncaught errors
-      if (arguments[0]) {
-        throw arguments[0];
-      }
-      return;
-    }
+		// Check if there are no steps left
+		if (steps.length === 0) {
+			// Throw uncaught errors
+			if (arguments[0]) {
+				throw arguments[0];
+			}
+			return;
+		}
 
-    // Get the next step to execute
-    var fn = steps.shift();
-    results = [null];
+		// Get the next step to execute
+		var fn = steps.shift();
+		results = [null];
 
-    // Run the step in a try..catch block so exceptions don't get out of hand.
-    try {
-      lock = true;
-      var result = fn.apply(next, arguments);
-    } catch (e) {
-      // Pass any exceptions on through the next callback
-      next(e);
-    }
+		// Run the step in a try..catch block so exceptions don't get out of hand.
+		try {
+			lock = true;
+			var result = fn.apply(next, arguments);
+		} catch (e) {
+			// Pass any exceptions on through the next callback
+			next(e);
+		}
 
-    if (counter > 0 && pending == 0) {
-      // If parallel() was called, and all parallel branches executed
-      // synchronously, go on to the next step immediately.
-      next.apply(null, results);
-    } else if (result !== undefined) {
-      // If a synchronous return is used, pass it to the callback
-      next(null, result);
-    }
-    lock = false;
-  }
+		if (counter > 0 && pending == 0) {
+			// If parallel() was called, and all parallel branches executed
+			// synchronously, go on to the next step immediately.
+			next.apply(null, results);
+		} else if (result !== undefined) {
+			// If a synchronous return is used, pass it to the callback
+			next(null, result);
+		}
+		lock = false;
+	}
 
-  // Add a special callback generator `this.parallel()` that groups stuff.
-  next.parallel = function (isGrouped) {
-    var index = 1 + counter++;
-    pending++;
+	// Add a special callback generator `this.parallel()` that groups stuff.
+	next.parallel = function (isGrouped) {
+		var index = 1 + counter++;
+		pending++;
 
-    return function (err, ...args) {
-      pending--;
-      // Compress the error from any result to the first argument
-      if (err) {
-        results[0] = err;
-      }
-      // Send the other results as arguments
-      results[index] = args;
-      if (!lock && pending === 0) {
-        // When all parallel branches done, call the callback
-        if (isGrouped) {
-            next.apply(null, [results[0], ...results[1]]);
-        }
-        else {
-            next.apply(null, results);
-        }
-      }
-    };
-  };
+		return function (err, ...args) {
+			pending--;
+			// Compress the error from any result to the first argument
+			if (err) {
+				results[0] = err;
+			}
+			// Send the other results as arguments
+			results[index] = args;
+			if (!lock && pending === 0) {
+				// When all parallel branches done, call the callback
+				if (isGrouped) {
+					next.apply(null, [results[0], ...results[1]]);
+				}
+				else {
+					next.apply(null, results);
+				}
+			}
+		};
+	};
 
-  // Generates a callback generator for grouped results
-  next.group = function () {
-    var localCallback = next.parallel(true);
-    var counter = 0;
-    var pending = 0;
-    var result = [[]];
-    var error = null;
+	// Generates a callback generator for grouped results
+	next.group = function () {
+		var localCallback = next.parallel(true);
+		var counter = 0;
+		var pending = 0;
+		var result = [[]];
+		var error = null;
 
-    function check() {
-      if (pending === 0) {
-        // When group is done, call the callback
-        localCallback(error, ...result);
-      }
-    }
-    process.nextTick(check); // Ensures that check is called at least once
+		function check() {
+			if (pending === 0) {
+				// When group is done, call the callback
+				localCallback(error, ...result);
+			}
+		}
+		process.nextTick(check); // Ensures that check is called at least once
 
-    // Generates a callback for the group
-    return function () {
-      var index = counter++;
-      pending++;
-      return function (err, ...args) {
-        pending--;
-        // Compress the error from any result to the first argument
-        if (err) {
-          error = err;
-        }
-        // Send the other results as arguments
-        for (var i=0; i<args.length; i++) {
-            if (result[i] === undefined) {
-                result[i] = [];
-            }
-            result[i][index] = args[i];
-        }
-        if (!lock) { check(); }
-      };
-    };
-  };
+		// Generates a callback for the group
+		return function () {
+			var index = counter++;
+			pending++;
+			return function (err, ...args) {
+				pending--;
+				// Compress the error from any result to the first argument
+				if (err) {
+					error = err;
+				}
+				// Send the other results as arguments
+				for (var i=0; i<args.length; i++) {
+					if (result[i] === undefined) {
+						result[i] = [];
+					}
+					result[i][index] = args[i];
+				}
+				if (!lock) { check(); }
+			};
+	    };
+	};
 
-  // Start the engine an pass nothing to the first step.
-  next();
+	// Start the engine an pass nothing to the first step.
+	next();
 }
 
 // Tack on leading and tailing steps for input and output and return
 // the whole thing as a function.  Basically turns step calls into function
 // factories.
-Step.fn = function StepFn() {
-  var steps = Array.prototype.slice.call(arguments);
-  return function () {
-    var args = Array.prototype.slice.call(arguments);
+Step.fn = function StepFn(...steps) {
+	return function (...args) {
+		// Insert a first step that primes the data stream
+		var toRun = [function () {
+			this.apply(null, args);
+		}].concat(steps);
 
-    // Insert a first step that primes the data stream
-    var toRun = [function () {
-      this.apply(null, args);
-    }].concat(steps);
+		// If the last arg is a function add it as a last step
+		if (typeof args[args.length-1] === 'function') {
+			toRun.push(args.pop());
+		}
 
-    // If the last arg is a function add it as a last step
-    if (typeof args[args.length-1] === 'function') {
-      toRun.push(args.pop());
-    }
-
-
-    Step.apply(null, toRun);
-  }
+		Step.apply(null, toRun);
+	}
 }
-
 
 // Hook into commonJS module systems
 if (typeof module !== 'undefined' && "exports" in module) {
-  module.exports = Step;
+	module.exports = Step;
 }

--- a/lib/step.js
+++ b/lib/step.js
@@ -24,135 +24,139 @@ SOFTWARE.
 
 // Inspired by http://github.com/willconant/flow-js, but reimplemented and
 // modified to fit my taste and the node.JS error handling system.
-// futher modified by Sandon Joubert <sandon.joubert1@gmail.com> with minor
-//  functionality changes, and bug fixes, now requires nodejs >= 6.0.0
-function Step(...steps) {
-	var pending, counter, results, lock;
+function Step() {
+  var steps = Array.prototype.slice.call(arguments),
+      pending, counter, results, lock;
 
-	// Define the main callback that's given as `this` to the steps.
-	function next() {
-		counter = pending = 0;
+  // Define the main callback that's given as `this` to the steps.
+  function next() {
+    counter = pending = 0;
 
-		// Check if there are no steps left
-		if (steps.length === 0) {
-			// Throw uncaught errors
-			if (arguments[0]) {
-				throw arguments[0];
-			}
-			return;
-		}
+    // Check if there are no steps left
+    if (steps.length === 0) {
+      // Throw uncaught errors
+      if (arguments[0]) {
+        throw arguments[0];
+      }
+      return;
+    }
 
-		// Get the next step to execute
-		var fn = steps.shift();
-		results = [null];
+    // Get the next step to execute
+    var fn = steps.shift();
+    results = [null];
 
-		// Run the step in a try..catch block so exceptions don't get out of hand.
-		try {
-			lock = true;
-			var result = fn.apply(next, arguments);
-		} catch (e) {
-			// Pass any exceptions on through the next callback
-			next(e);
-		}
+    // Run the step in a try..catch block so exceptions don't get out of hand.
+    try {
+      lock = true;
+      var result = fn.apply(next, arguments);
+    } catch (e) {
+      // Pass any exceptions on through the next callback
+      next(e);
+    }
 
-		if (counter > 0 && pending == 0) {
-			// If parallel() was called, and all parallel branches executed
-			// synchronously, go on to the next step immediately.
-			next.apply(null, results);
-		} else if (result !== undefined) {
-			// If a synchronous return is used, pass it to the callback
-			next(null, result);
-		}
-		lock = false;
-	}
+    if (counter > 0 && pending == 0) {
+      // If parallel() was called, and all parallel branches executed
+      // synchronously, go on to the next step immediately.
+      next.apply(null, results);
+    } else if (result !== undefined) {
+      // If a synchronous return is used, pass it to the callback
+      next(null, result);
+    }
+    lock = false;
+  }
 
-	// Add a special callback generator `this.parallel()` that groups stuff.
-	next.parallel = function (isGrouped) {
-		var index = 1 + counter++;
-		pending++;
+  // Add a special callback generator `this.parallel()` that groups stuff.
+  next.parallel = function (isGrouped) {
+    var index = 1 + counter++;
+    pending++;
 
-		return function (err, ...args) {
-			pending--;
-			// Compress the error from any result to the first argument
-			if (err) {
-				results[0] = err;
-			}
-			// Send the other results as arguments
-			results[index] = args;
-			if (!lock && pending === 0) {
-				// When all parallel branches done, call the callback
-				if (isGrouped) {
-					next.apply(null, [results[0], ...results[1]]);
-				}
-				else {
-					next.apply(null, results);
-				}
-			}
-		};
-	};
+    return function (err, ...args) {
+      pending--;
+      // Compress the error from any result to the first argument
+      if (err) {
+        results[0] = err;
+      }
+      // Send the other results as arguments
+      results[index] = args;
+      if (!lock && pending === 0) {
+        // When all parallel branches done, call the callback
+        if (isGrouped) {
+            next.apply(null, [results[0], ...results[1]]);
+        }
+        else {
+            next.apply(null, results);
+        }
+      }
+    };
+  };
 
-	// Generates a callback generator for grouped results
-	next.group = function () {
-		var localCallback = next.parallel(true);
-		var counter = 0;
-		var pending = 0;
-		var result = [[]];
-		var error = null;
+  // Generates a callback generator for grouped results
+  next.group = function () {
+    var localCallback = next.parallel(true);
+    var counter = 0;
+    var pending = 0;
+    var result = [[]];
+    var error = null;
 
-		function check() {
-			if (pending === 0) {
-				// When group is done, call the callback
-				localCallback(error, ...result);
-			}
-		}
-		process.nextTick(check); // Ensures that check is called at least once
+    function check() {
+      if (pending === 0) {
+        // When group is done, call the callback
+        localCallback(error, ...result);
+      }
+    }
+    process.nextTick(check); // Ensures that check is called at least once
 
-		// Generates a callback for the group
-		return function () {
-			var index = counter++;
-			pending++;
-			return function (err, ...args) {
-				pending--;
-				// Compress the error from any result to the first argument
-				if (err) {
-					error = err;
-				}
-				// Send the other results as arguments
-				for (var i=0; i<args.length; i++) {
-					if (result[i] === undefined) {
-						result[i] = [];
-					}
-					result[i][index] = args[i];
-				}
-				if (!lock) { check(); }
-			};
-	    };
-	};
+    // Generates a callback for the group
+    return function () {
+      var index = counter++;
+      pending++;
+      return function (err, ...args) {
+        pending--;
+        // Compress the error from any result to the first argument
+        if (err) {
+          error = err;
+        }
+        // Send the other results as arguments
+        for (var i=0; i<args.length; i++) {
+            if (result[i] === undefined) {
+                result[i] = [];
+            }
+            result[i][index] = args[i];
+        }
+        if (!lock) { check(); }
+      };
+    };
+  };
 
-	// Start the engine an pass nothing to the first step.
-	next();
+  // Start the engine an pass nothing to the first step.
+  next();
 }
 
 // Tack on leading and tailing steps for input and output and return
 // the whole thing as a function.  Basically turns step calls into function
 // factories.
-Step.fn = function StepFn(...steps) {
-	return function (...args) {
-		// Insert a first step that primes the data stream
-		var toRun = [function () {
-			this.apply(null, args);
-		}].concat(steps);
+Step.fn = function StepFn() {
+  var steps = Array.prototype.slice.call(arguments);
+  return function () {
+    var args = Array.prototype.slice.call(arguments);
 
-		// If the last arg is a function add it as a last step
-		if (typeof args[args.length-1] === 'function') {
-			toRun.push(args.pop());
-		}
+    // Insert a first step that primes the data stream
+    var toRun = [function () {
+      this.apply(null, args);
+    }].concat(steps);
 
-		Step.apply(null, toRun);
-	}
+    // If the last arg is a function add it as a last step
+    if (typeof args[args.length-1] === 'function') {
+      toRun.push(args.pop());
+    }
+
+
+    Step.apply(null, toRun);
+  }
 }
+
 
 // Hook into commonJS module systems
 if (typeof module !== 'undefined' && "exports" in module) {
-	module.exports = Step;
+  module.exports = Step;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name": "step",
   "version": "1.0.0",
   "description": "A simple control-flow library for node.JS that makes parallel execution, serial execution, and error handling painless.",
-  "engine": [ "node >=0.2.0" ],
+  "engine": [ "node >=6.0.0" ],
   "author": "Tim Caswell <tim@creationix.com>",
   "license": "MIT",
   "repository":

--- a/test/groupTest.js
+++ b/test/groupTest.js
@@ -59,7 +59,7 @@ Step(
         if(err) throw err;
         fulfill("test3: " + num);
         var group = this.group();
-        
+
         setTimeout((function(callback) { return function() { callback(null, 1); } })(group()), 100);
         group()(null, 2);
         setTimeout((function(callback) { return function() { callback(null, 3); } })(group()), 0);

--- a/test/spreadTest.js
+++ b/test/spreadTest.js
@@ -11,7 +11,7 @@ Step(
 		doThis(this, 0, 1, 2, 3, {Obj: "str"});
 	},
 	function one(err, ...args) {
-		console.log("one: ", err, ...args);
+		//console.log("one: ", err, ...args);
 		if (err) throw err;
 		fulfill('one');
 		assert.equal(args[3], 3, "single callback success");
@@ -20,7 +20,7 @@ Step(
 		doThis(this.parallel(), 1, "1", "11");
 	},
 	function two(err, ...args) {
-		console.log("two: ", err, ...args);
+		//console.log("two: ", err, ...args);
 		if (err) throw err;
 		fulfill('two');
 		assert.equal(args.length, 2, "parallel callback success");
@@ -31,7 +31,7 @@ Step(
 		}
 	},
 	function three(err, ...args) {
-		console.log("three: ", err, ...args);
+		//console.log("three: ", err, ...args);
 		if (err) throw err;
 		fulfill('three');
 		assert.equal(args.length, 3, "group callback success");
@@ -42,7 +42,7 @@ Step(
 		}
 	},
 	function four(err, ...args) {
-		console.log("four: ", err, ...args);
+		//console.log("four: ", err, ...args);
 		if (err) {
 			process.exit(1);
 		}
@@ -54,7 +54,7 @@ Step(
 );
 
 function doThis(callback, ...args) {
-	fs.readFile(__dirname + "/test.txt", function(err) {
+	fs.readFile(__dirname + "/helper.js", function(err) {
 		callback(err, ...args);
 	});
 }

--- a/test/spreadTest.js
+++ b/test/spreadTest.js
@@ -1,0 +1,60 @@
+require('./helper');
+
+expect('zero');
+expect('one');
+expect('two');
+expect('three');
+expect('four');
+Step(
+	function zero() {
+		fulfill('zero');
+		doThis(this, 0, 1, 2, 3, {Obj: "str"});
+	},
+	function one(err, ...args) {
+		console.log("one: ", err, ...args);
+		if (err) throw err;
+		fulfill('one');
+		assert.equal(args[3], 3, "single callback success");
+
+		doThis(this.parallel(), 0, "0", "00");
+		doThis(this.parallel(), 1, "1", "11");
+	},
+	function two(err, ...args) {
+		console.log("two: ", err, ...args);
+		if (err) throw err;
+		fulfill('two');
+		assert.equal(args.length, 2, "parallel callback success");
+
+		var group = this.group();
+		for (var i=0; i<7; i++) {
+			doThis(group(), i, String(i), "pizza");
+		}
+	},
+	function three(err, ...args) {
+		console.log("three: ", err, ...args);
+		if (err) throw err;
+		fulfill('three');
+		assert.equal(args.length, 3, "group callback success");
+
+		var group = this.group();
+		for (var i=0; i<3; i++) {
+			doThis(group(), i);
+		}
+	},
+	function four(err, ...args) {
+		console.log("four: ", err, ...args);
+		if (err) {
+			process.exit(1);
+		}
+		else {
+			fulfill('four');
+			process.exit(0);
+		}
+	}
+);
+
+function doThis(callback, ...args) {
+	fs.readFile(__dirname + "/test.txt", function(err) {
+		callback(err, ...args);
+	});
+}

--- a/test/test.txt
+++ b/test/test.txt
@@ -1,0 +1,1 @@
+This is a text file

--- a/test/test.txt
+++ b/test/test.txt
@@ -1,1 +1,0 @@
-This is a text file


### PR DESCRIPTION
Reasons for this pull request can be seen in [issue 58](https://github.com/creationix/step/issues/58). 

One possible issue, up to the author is that I make use of the spread and rest operators (...) which is only available from node version 6.0.0 and onwards.